### PR TITLE
REFACTOR: Removed reliance on precompiled header

### DIFF
--- a/Classes/Classes/ABXApiClient.h
+++ b/Classes/Classes/ABXApiClient.h
@@ -5,10 +5,10 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import UIKit;
 
 // Error codes
-typedef enum {
+typedef NS_ENUM(NSUInteger, ABXResponseCode) {
     ABXResponseCodeSuccess,       // Request completed successfully
     ABXResponseCodeErrorAuth,     // Check your bundle identifier and API key
     ABXResponseCodeErrorExpired,  // Account requires payment
@@ -16,7 +16,7 @@ typedef enum {
     ABXResponseCodeErrorEncoding, // Error encoding the post/put request
     ABXResponseCodeErrorNotFound, // Not found
     ABXResponseCodeErrorUnknown   // Unknown error
-} ABXResponseCode;
+};
 
 typedef void (^ABXRequestCompletion)(ABXResponseCode responseCode, NSInteger httpCode, NSError *error, id JSON);
 

--- a/Classes/Classes/ABXAppStore.h
+++ b/Classes/Classes/ABXAppStore.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import UIKit;
 
 @interface ABXAppStore : NSObject
 

--- a/Classes/Classes/NSDictionary+ABXNSNullAsNull.h
+++ b/Classes/Classes/NSDictionary+ABXNSNullAsNull.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface NSDictionary (ABXNSNullAsNull)
 

--- a/Classes/Classes/NSDictionary+ABXQueryString.h
+++ b/Classes/Classes/NSDictionary+ABXQueryString.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface NSDictionary (ABXQueryString)
 

--- a/Classes/Classes/NSString+ABXLocalized.h
+++ b/Classes/Classes/NSString+ABXLocalized.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface NSString (ABXLocalized)
 

--- a/Classes/Classes/NSString+ABXSizing.h
+++ b/Classes/Classes/NSString+ABXSizing.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import UIKit;
 
 @interface NSString (ABXSizing)
 

--- a/Classes/Classes/NSString+ABXURLEncoding.h
+++ b/Classes/Classes/NSString+ABXURLEncoding.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface NSString (ABXURLEncoding)
 

--- a/Classes/Classes/UIViewController+ABXScreenshot.h
+++ b/Classes/Classes/UIViewController+ABXScreenshot.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface UIViewController (ABXScreenshot)
 

--- a/Classes/Controllers/ABXBaseListViewController.h
+++ b/Classes/Controllers/ABXBaseListViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface ABXBaseListViewController : UIViewController
 

--- a/Classes/Controllers/ABXFAQViewController.h
+++ b/Classes/Controllers/ABXFAQViewController.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @class ABXFaq;
 

--- a/Classes/Controllers/ABXFAQsViewController.h
+++ b/Classes/Controllers/ABXFAQsViewController.h
@@ -5,8 +5,6 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 #import "ABXBaseListViewController.h"
 
 @interface ABXFAQsViewController : ABXBaseListViewController

--- a/Classes/Controllers/ABXFeedbackViewController.h
+++ b/Classes/Controllers/ABXFeedbackViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface ABXFeedbackViewController : UIViewController
 

--- a/Classes/Controllers/ABXNavigationController.h
+++ b/Classes/Controllers/ABXNavigationController.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2014 Stuart Hall. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface ABXNavigationController : UINavigationController
 

--- a/Classes/Controllers/ABXVersionsViewController.h
+++ b/Classes/Controllers/ABXVersionsViewController.h
@@ -5,8 +5,6 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 #import "ABXBaseListViewController.h"
 
 @interface ABXVersionsViewController : ABXBaseListViewController

--- a/Classes/Models/ABXFaq.h
+++ b/Classes/Models/ABXFaq.h
@@ -5,8 +5,6 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 #import "ABXModel.h"
 
 @interface ABXFaq : ABXModel

--- a/Classes/Models/ABXModel.h
+++ b/Classes/Models/ABXModel.h
@@ -5,8 +5,6 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 #import "ABXApiClient.h"
 
 // Protected methods

--- a/Classes/Models/ABXNotification.h
+++ b/Classes/Models/ABXNotification.h
@@ -5,8 +5,6 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 #import "ABXModel.h"
 
 @interface ABXNotification : ABXModel

--- a/Classes/Models/ABXVersion.h
+++ b/Classes/Models/ABXVersion.h
@@ -5,8 +5,6 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-
 #import "ABXModel.h"
 
 @interface ABXVersion : ABXModel

--- a/Classes/Views/ABXFAQTableViewCell.h
+++ b/Classes/Views/ABXFAQTableViewCell.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @class ABXFaq;
 

--- a/Classes/Views/ABXNotificationTableViewCell.h
+++ b/Classes/Views/ABXNotificationTableViewCell.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 #import "ABXNotification.h"
 #import "ABXVersion.h"

--- a/Classes/Views/ABXNotificationView.h
+++ b/Classes/Views/ABXNotificationView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @class ABXNotificationView;
 

--- a/Classes/Views/ABXPromptView.h
+++ b/Classes/Views/ABXPromptView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @protocol ABXPromptViewDelegate <NSObject>
 

--- a/Classes/Views/ABXTextView.h
+++ b/Classes/Views/ABXTextView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface ABXTextView : UITextView
 

--- a/Classes/Views/ABXVersionTableViewCell.h
+++ b/Classes/Views/ABXVersionTableViewCell.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Appbot. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @class ABXVersion;
 

--- a/Example/Sample Project/ABXAppDelegate.m
+++ b/Example/Sample Project/ABXAppDelegate.m
@@ -7,6 +7,7 @@
 //
 
 #import "ABXAppDelegate.h"
+#import "ABX.h"
 
 @implementation ABXAppDelegate
 

--- a/Example/Sample Project/ABXViewController.m
+++ b/Example/Sample Project/ABXViewController.m
@@ -80,7 +80,7 @@ static NSString* const kiTunesID = @"650762525";
                 break;
                 
             default: {
-                [self showAlert:@"Versions" message:[NSString stringWithFormat:@"%u", responseCode]];
+                [self showAlert:@"Versions" message:[NSString stringWithFormat:@"%lu", (unsigned long)responseCode]];
             }
                 break;
         }
@@ -111,7 +111,7 @@ static NSString* const kiTunesID = @"650762525";
                 break;
                 
             default: {
-                [self showAlert:@"FAQs" message:[NSString stringWithFormat:@"%u", responseCode]];
+                [self showAlert:@"FAQs" message:[NSString stringWithFormat:@"%lu", (unsigned long)responseCode]];
             }
                 break;
         }

--- a/Example/Sample Project/Sample Project-Prefix.pch
+++ b/Example/Sample Project/Sample Project-Prefix.pch
@@ -11,8 +11,5 @@
 #endif
 
 #ifdef __OBJC__
-    #import <UIKit/UIKit.h>
-    #import <Foundation/Foundation.h>
 
-    #import "ABX.h"
 #endif


### PR DESCRIPTION
How do you feel about @importing Foundation and UIKit directly into the files that require those them? I ask because starting with 6.2 Xcode no longer includes a precompiled header. These changes will help ease the setup process in newer projects without creating more work for those that already use precompiled headers. I also updated enums to use the NS_ENUM to make for better bridging with Swift.