### PR TITLE
Add a description so it passes validation errors

### DIFF
--- a/appbotx.podspec
+++ b/appbotx.podspec
@@ -8,8 +8,7 @@ Pod::Spec.new do |s|
   s.name             = "AppbotX"
   s.version          = "1.1.1"
   s.summary          = "AppbotX is an Obj-C lib for the Appbot server."
-  s.description      = <<-DESC
-                       DESC
+  s.description      = "iOS Support Frameworks and UI for AppbotX tools to talk to the Appbot server."
   s.homepage         = "http://appbot.co"
   s.license          = 'MIT'
   s.author           = { "Stuart Hall" => "stuartkhall@gmail.com" }


### PR DESCRIPTION
Current Cococapods betas refuse to install the pod as it has an empty description.