### PR TITLE
Support appstore on iOS 9+

### DIFF
--- a/Classes/Classes/ABXAppStore.m
+++ b/Classes/Classes/ABXAppStore.m
@@ -11,7 +11,12 @@
 
 + (void)openAppStoreReviewForApp:(NSString*)itunesId
 {
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"7.1" options:NSNumericSearch] != NSOrderedAscending) {
+   NSString *version = [[UIDevice currentDevice] systemVersion];
+    if ([version compare:@"9.0" options:NSNumericSearch] != NSOrderedAscending) {
+        // iOS 9 changes the app store links.
+        NSString *url = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software", itunesId];
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
+    } else if ([version compare:@"7.1" options:NSNumericSearch] != NSOrderedAscending) {
         // Since 7.1 we can throw to the review tab
         NSString *url = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&ct=appbotReviewPrompt&at=11l4LZ&type=Purple%%252BSoftware&mt=8&sortOrdering=2", itunesId];
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];


### PR DESCRIPTION
The existing links cause issues on iOS9, showing an error page.